### PR TITLE
Optimize "naive" approach computations.

### DIFF
--- a/fastgc/run_algo.py
+++ b/fastgc/run_algo.py
@@ -97,8 +97,8 @@ def train_and_eval(device, train_loader, test_loader, input_size, output_size,
                                               clip_thresh / grad_norm.detach()) / batch_size
                 loss.backward(sample_weight)
             elif model.train_alg == 'naive':
-                grad = clip_grad_norm(model, device, data, target, criterion, clip_thresh)
-    
+                grad = clip_grad_norm(model, device, loss, clip_thresh)
+
                 for j, param in enumerate(filter(lambda x: x.requires_grad, model.parameters())):
                     param.grad = grad[j] / batch_size
             elif model.train_alg == 'batch':


### PR DESCRIPTION
 Hello,

I have been reading your paper "Scaling up Differentially Private Deep Learning  with Fast Per-Example Gradient Clipping", which I found very interesting and insightful.

However, when consulting the associated source code I noticed what I think is a slight maladjustment in the `run_algo.py` code and/or the `clip_grad_norm` function. Indeed, in the `train_and_eval` function you first run the model's forward pass and then compute the backward with the selected strategy ; but in the "naive" one, the backend code actually compute the forward pass again (and does so for each and every sample).

It appears to me that this puts the "naive" approach to an unfair disadvantage as compared with alternative approaches; I believe that it would be better to: (a) re-use the computed sample-wise loss from the forward pass and (b) iteratively call `loss[i].backward(retain_graph=True)`. This way some computations would not be uselessly re-run for each and every sample.

This merge request implements the former revision. I have not been able to run the experiments themselves, however even on CPU and using a very simple 1-layer model, one can easily test that re-using the batch-computed, sample-wise loss rather than iterating over single samples yields significant improvements - while still being _way_ slower than applying a batched backward pass. See the following example code:
```python
from timeit import timeit

import torch


# Shallow regression model with random data.
module = torch.nn.Sequential(
    torch.nn.Linear(8, 1),
    torch.nn.Flatten(0)
)
loss_fn = torch.nn.MSELoss(reduction='none')
inputs = torch.randn(size=(32, 8))
target = torch.randn(size=(32,))


def backward_simple():
    """Run batched forward and backward pass."""
    module.zero_grad()
    pred = module(inputs)
    loss = loss_fn(pred, target)
    loss.mean().backward()
    return [p.grad.detach().clone() for p in module.parameters()]


def backward_samplewise():
    """Run sample-wise forward and backward passes."""
    module.zero_grad()
    params = [p for p in module.parameters() if p.requires_grad]
    grads = [p.grad.detach().clone() for p in params]
    for i in range(len(inputs)):
        module.zero_grad()
        pred = module(inputs[i:i+1])
        loss = loss_fn(pred, target[i:i+1])
        loss.backward()
        for g, p in zip(grads, params):
            g.add_(p.grad)
    return [g / len(inputs) for g in grads]


def backward_iterative():
    """Run batched forward pass and sample-wise backward ones."""
    module.zero_grad()
    params = [p for p in module.parameters() if p.requires_grad]
    grads = [p.grad.detach().clone() for p in params]
    pred = module(inputs)
    loss = loss_fn(pred, target)
    for i in range(len(loss)):
        loss[i].backward(retain_graph=True)
        for g, p in zip(grads, params):
            g.add_(p.grad)
        module.zero_grad()
    return [g / len(loss) for g in grads]


# These results will differ depending on computational resources.
print(timeit(lambda: backward_simple(), number=100))
# >>> 0.01769781100028922
print(timeit(lambda: backward_samplewise(), number=100))
# >>> 0.25882676000037463
print(timeit(lambda: backward_iterative(), number=100))
# >>> 0.17733271900033287
```

I don't expect this code revision to impact your experimental results by a lot, and obviously this does not diminish whatsoever the interest of your theoretical work (and its implementation) on clipping gradients through loss re-weighting. Still, correcting the code and re-running the experiments would probably have the results in the paper be more honest as to the cost of the "naive" approach.